### PR TITLE
Carry bundler cache over to deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,14 @@ jobs:
       command: /sbin/init
     steps:
     - checkout
+    - restore_cache:
+        keys:
+        - v1-dep-{{ .Branch }}-
+        - v1-dep-master-
+        - v1-dep-
+    - run: echo -e "export RAILS_ENV=test\nexport RACK_ENV=test" >> $BASH_ENV
+    - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle
+        --jobs=4 --retry=3 '
     - run: 'bundle exec s3_website push'
 
 workflows:


### PR DESCRIPTION
We're currently installing gems in the test job but expecting them to exist for the deploy job.