### PR TITLE
Check for policies file instead of root before pushing site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
         - v1-dep-{{ .Branch }}-{{ .Revision }}-
     - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 '
     - run: 'ls -R _site'
-    - run: 'ls _site/index.html && bundle exec s3_website push'
+    - run: 'ls _site/policies/index.html && bundle exec s3_website push'
 
 workflows:
   version: 2


### PR DESCRIPTION
We have a step in our build process to make sure that the `jekyll build` step has run to completion before we push the new site content up, but we no longer build the root `index.html` (as of https://github.com/DocuTAP/www.clockwisemd.com/pull/20).  Instead, we can still double check that the right files are in place by looking for the _policies_ `index.html`, which we do still build and serve directly.