### PR TITLE
Switch back to older image for site builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,4 +47,3 @@ workflows:
             branches:
               only:
                 - master
-                - hotfix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,7 @@ jobs:
   test:
     <<: *defaults
     steps:
-      - run: sudo /sbin/init
       - checkout
-      - restore_cache:
-          keys:
-          - v1-dep-{{ .Branch }}-
-          - v1-dep-master-
-          - v1-dep-
       - run: 'bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3 '
       - run: bundle exec jekyll build
       - save_cache:
@@ -33,7 +27,6 @@ jobs:
   deploy:
     <<: *defaults
     steps:
-      - run: sudo /sbin/init
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: circleci/ruby:2.5-node-browsers
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
       environment:
         BUNDLE_JOBS: 3
         BUNDLE_RETRY: 3
@@ -16,6 +16,7 @@ jobs:
   test:
     <<: *defaults
     steps:
+      - run: sudo /sbin/init
       - checkout
       - restore_cache:
           keys:
@@ -32,6 +33,7 @@ jobs:
   deploy:
     <<: *defaults
     steps:
+      - run: sudo /sbin/init
       - checkout
       - restore_cache:
           keys:
@@ -52,3 +54,4 @@ workflows:
             branches:
               only:
                 - master
+                - hotfix


### PR DESCRIPTION
Successful build (under a different branch name) [here](https://circleci.com/workflow-run/ecc3404b-f61a-4c73-afcf-1a0acb62ce06)

This gets us back to a runtime that the unmaintained `s3_website` gem can handle.  This stock image is not ideal (notably: it's huge), but it's at least known to work.

The initial cache restoration had to go because this version does everything as a user named `ubuntu` but the branch caches are all populated with files under `/home/circleci`, which no longer exists.  Once this version runs at least once on master, we should be able to put that restore step back in and recoup whatever time savings it was giving us.